### PR TITLE
Fix Player::IsFlying bug

### DIFF
--- a/source/common/player.cpp
+++ b/source/common/player.cpp
@@ -64,7 +64,7 @@ bool Player::IsLanded() { return this->status == PLAYER_STATUS::LANDED; }
 bool Player::IsAlive() { return this->status != PLAYER_STATUS::DEAD; }
 
 // Is the player flying
-bool Player::IsFlying() { return this->status != PLAYER_STATUS::FLYING; }
+bool Player::IsFlying() { return this->status == PLAYER_STATUS::FLYING; }
 
 // Lift Off a player, return true if succesful
 // Serverside


### PR DESCRIPTION
## Summary
- correct Player::IsFlying() so it returns true only when the player is actually flying

## Testing
- `make test` *(fails: gtest headers missing)*
- `make -k` *(fails: SDL3 headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685816b463f48326a38ae20257c43c1b