### PR TITLE
Split server and client builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,17 @@ DEBUG_FLAGS = -g -O0 -DDEBUG_BUILD
 # Source and object files
 SRC_DIR = source
 SRC = $(shell find $(SRC_DIR) -name '*.cpp')
-SRC_NO_MAIN = $(filter-out source/main.cpp, $(SRC))
-OBJ = $(SRC:.cpp=.o)
-EXEC = shipz
+COMMON_SRC = $(filter-out source/main.cpp source/client_main.cpp source/server_main.cpp, $(SRC))
+COMMON_OBJ = $(COMMON_SRC:.cpp=.o)
+
+SERVER_OBJ = $(COMMON_OBJ) source/server_main.o
+CLIENT_OBJ = $(COMMON_OBJ) source/client_main.o
+
+SERVER_EXEC = server
+CLIENT_EXEC = client
+
+SRC_NO_MAIN = $(COMMON_SRC)
+OBJ = $(SERVER_OBJ) $(CLIENT_OBJ)
 
 # Test directory and test files
 TEST_DIR = tests
@@ -21,12 +29,14 @@ ALL_TEST_SRC = $(TESTSRC) $(SRC_NO_MAIN)
 TESTOBJ = $(ALL_TEST_SRC:.cpp=.o)
 TESTEXEC = test_program
 
-# Build target
-all: $(EXEC)
+# Build targets
+all: $(SERVER_EXEC) $(CLIENT_EXEC)
 
-$(EXEC): $(OBJ)
+$(SERVER_EXEC): $(SERVER_OBJ)
 	$(CXX) -o $@ $^ $(LDFLAGS)
-	# export DYLD_LIBRARY_PATH=$(RPATH)
+
+$(CLIENT_EXEC): $(CLIENT_OBJ)
+	$(CXX) -o $@ $^ $(LDFLAGS)
 
 # %.o: %.cpp
 # 	$(CXX) -c $(CXXFLAGS) $< -o $@
@@ -36,7 +46,7 @@ $(EXEC): $(OBJ)
 
 # Debug build target
 debug: CXXFLAGS += $(DEBUG_FLAGS)  # Add debug flags to CXXFLAGS
-debug: $(EXEC)
+debug: $(SERVER_EXEC) $(CLIENT_EXEC)
 
 # Compile and run all gtest files
 test: $(TESTOBJ) 
@@ -48,7 +58,7 @@ $(TESTDIR)/%.o: $(TESTDIR)/%.cpp
 
 # Clean up build files
 clean:
-	rm -f $(OBJ) $(EXEC) $(TESTOBJ) $(TESTEXEC)
+	        rm -f $(OBJ) $(SERVER_EXEC) $(CLIENT_EXEC) $(TESTOBJ) $(TESTEXEC)
 
 .PHONY: all clean
 

--- a/source/client_main.cpp
+++ b/source/client_main.cpp
@@ -1,0 +1,41 @@
+#include <SDL3/SDL.h>
+#include <cmdparser.hpp>
+#include <iostream>
+
+#include "client/client.h"
+#include "client/gfx.h"
+#include "common/globals.h"
+#include "common/other.h"
+
+void ConfigureClientParser(cli::Parser& parser) {
+    parser.set_optional<bool>("F", "fullscreen", false, "Run fullscreen");
+    parser.set_optional<uint16_t>("l", "listen", PORT_CLIENT,
+                                  "The port to listen on");
+    parser.set_optional<std::string>("a", "address", "localhost",
+                                     "The server host address");
+    parser.set_optional<std::string>("n", "nickname", "UnnamedPlayer",
+                                     "Your nickname");
+}
+
+int main(int argc, char* argv[]) {
+    cli::Parser parser(argc, argv);
+    ConfigureClientParser(parser);
+    parser.run_and_exit_if_error();
+
+    InitSDL();
+
+    try {
+        InitVid(parser.get<bool>("F"));
+        auto listen_port = parser.get<uint16_t>("l");
+        auto address = parser.get<std::string>("a");
+        auto nickname = parser.get<std::string>("n");
+
+        Client client(address.c_str(), nickname.c_str(), listen_port, PORT_SERVER);
+        client.Run();
+    } catch (const std::runtime_error& e) {
+        log::error("a fatal error occured:", e.what());
+    }
+
+    SDL_Quit();
+    EndMessage();
+}

--- a/source/server_main.cpp
+++ b/source/server_main.cpp
@@ -1,0 +1,31 @@
+#include <SDL3/SDL.h>
+#include <cmdparser.hpp>
+#include <iostream>
+
+#include "common/globals.h"
+#include "common/other.h"
+#include "server/server.h"
+
+void ConfigureServerParser(cli::Parser& parser) {
+    parser.set_optional<std::string>("f", "filename", "rusty.json",
+                                     "Which level to run");
+}
+
+int main(int argc, char* argv[]) {
+    cli::Parser parser(argc, argv);
+    ConfigureServerParser(parser);
+    parser.run_and_exit_if_error();
+
+    InitSDL();
+
+    try {
+        auto filename = parser.get<std::string>("f");
+        Server server(filename, PORT_SERVER, MAXPLAYERS);
+        server.Run();
+    } catch (const std::runtime_error& e) {
+        log::error("a fatal error occured:", e.what());
+    }
+
+    SDL_Quit();
+    EndMessage();
+}


### PR DESCRIPTION
## Summary
- create `client_main.cpp` and `server_main.cpp`
- build separate `server` and `client` binaries instead of single one

## Testing
- `make clean`
- `make` *(fails: SDL3 headers missing)*
- `make test` *(fails: gtest missing)*

------
https://chatgpt.com/codex/tasks/task_e_68581bc85004832687fbd4239785d11d